### PR TITLE
Eof/exchange

### DIFF
--- a/src/ethereum_test_tools/tests/test_vm.py
+++ b/src/ethereum_test_tools/tests/test_vm.py
@@ -261,6 +261,10 @@ from ..vm.opcode import Opcodes as Op
         (Op.RJUMPV[0, 3, 6, 9], bytes.fromhex("e2030000000300060009")),
         (Op.RJUMPV[2, 0], bytes.fromhex("e20100020000")),
         (Op.RJUMPV[b"\x02\x00\x02\xFF\xFF"], bytes.fromhex("e2020002ffff")),
+        (Op.EXCHANGE[0x2 + 0x0, 0x3 + 0x0], bytes.fromhex("e800")),
+        (Op.EXCHANGE[0x2 + 0x0, 0x3 + 0xF], bytes.fromhex("e80f")),
+        (Op.EXCHANGE[0x2 + 0xF, 0x3 + 0xF + 0x0], bytes.fromhex("e8f0")),
+        (Op.EXCHANGE[0x2 + 0xF, 0x3 + 0xF + 0xF], bytes.fromhex("e8ff")),
     ],
 )
 def test_opcodes(opcodes: bytes, expected: bytes):

--- a/src/ethereum_test_tools/vm/opcode.py
+++ b/src/ethereum_test_tools/vm/opcode.py
@@ -172,7 +172,10 @@ class Opcode(OpcodeMacroBase):
         data_portion = bytes()
 
         if self.data_portion_formatter is not None:
-            data_portion = self.data_portion_formatter(*args)
+            if len(args) == 1 and isinstance(args[0], Iterable) and not isinstance(args[0], bytes):
+                data_portion = self.data_portion_formatter(*args[0])
+            else:
+                data_portion = self.data_portion_formatter(*args)
         elif self.data_portion_length > 0:
             # For opcodes with a data portion, the first argument is the data and the rest of the
             # arguments form the stack.
@@ -253,8 +256,10 @@ class Opcode(OpcodeMacroBase):
             raise ValueError("Opcode with data portion requires at least one argument")
         if self.data_portion_formatter is not None:
             data_portion_arg = args.pop(0)
-            assert isinstance(data_portion_arg, Iterable)
-            data_portion = self.data_portion_formatter(*data_portion_arg)
+            if isinstance(data_portion_arg, Iterable) and not isinstance(data_portion_arg, bytes):
+                data_portion = self.data_portion_formatter(*data_portion_arg)
+            else:
+                data_portion = self.data_portion_formatter(data_portion_arg)
         elif self.data_portion_length > 0:
             # For opcodes with a data portion, the first argument is the data and the rest of the
             # arguments form the stack.
@@ -396,6 +401,27 @@ def _rjumpv_encoder(*args: int | bytes | Iterable[int]) -> bytes:
             if isinstance(i, int)
         ]
     )
+
+
+def _exchange_encoder(*args: int) -> bytes:
+    assert 1 <= len(args) <= 2, f"Exchange opcode requires one or two arguments, got {len(args)}"
+    if len(args) == 1:
+        return int.to_bytes(args[0], 1, "big")
+    # n = imm >> 4 + 1
+    # m = imm & 0xF + 1
+    # x = n + 1
+    # y = n + m + 1
+    # ...
+    # n = x - 1
+    # m = y - x
+    # m = y - n - 1
+    x, y = args
+    assert 2 <= x <= 0x11
+    assert x + 1 <= y <= x + 0x10
+    n = x - 1
+    m = y - x
+    imm = (n - 1) << 4 | m - 1
+    return int.to_bytes(imm, 1, "big")
 
 
 class Opcodes(Opcode, Enum):
@@ -4976,6 +5002,13 @@ class Opcodes(Opcode, Enum):
     Description
     ----
 
+    - deduct 3 gas
+    - read uint8 operand imm
+    - n = imm + 1
+    - n‘th (1-based) stack item is duplicated at the top of the stack
+    - Stack validation: stack_height >= n
+
+
     Inputs
     ----
 
@@ -4984,6 +5017,7 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
+    EOF Fork
 
     Gas
     ----
@@ -5000,6 +5034,13 @@ class Opcodes(Opcode, Enum):
     Description
     ----
 
+    - deduct 3 gas
+    - read uint8 operand imm
+    - n = imm + 1
+    - n + 1th stack item is swapped with the top stack item (1-based).
+    - Stack validation: stack_height >= n + 1
+
+
     Inputs
     ----
 
@@ -5008,23 +5049,29 @@ class Opcodes(Opcode, Enum):
 
     Fork
     ----
+    EOF Fork
 
     Gas
     ----
 
     """
 
-    EXCHANGE = Opcode(0xE8, data_portion_length=1)
+    EXCHANGE = Opcode(0xE8, data_portion_formatter=_exchange_encoder)
     """
     !!! Note: This opcode is under development
 
-    EXCHANGE[mn]
+    EXCHANGE[x, y]
     ----
 
     Description
     ----
     Exchanges two stack positions.  Two nybbles, n is high 4 bits + 1, then  m is 4 low bits + 1.
     Exchanges tne n+1'th item with the n + m + 1 item.
+
+    Inputs x and y when the opcode is used as `EXCHANGE[x, y]`, are equal to:
+    - x = n + 1
+    - y = n + m + 1
+    Which each equals to 1-based stack positions swapped.
 
     Inputs
     ----

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -164,6 +164,7 @@ hyperledger
 iat
 ignoreRevsFile
 img
+imm
 immediates
 incrementing
 init


### PR DESCRIPTION
## 🗒️ Description

Creates an encoder for the EXCHANGE opcode in the form of `EXCHANGE[x, y]` where `x` and `y` are the 1-based stack elements that are being swapped, and therefore have the following equivalences to the EIP values:
- `x = n + 1`
- `y = n + m + 1`

This, IMO, makes the opcode easier to use when writing bytecode for tests because the writer can know exactly which elements are being swapped, instead of having to apply the formula.

This PR also adds invalid container tests for when the `EXCHANGE` opcode is used to produce a stack underflow.