### PR TITLE
Add tests to Eof/rjump (and rebase)

### DIFF
--- a/src/ethereum_test_tools/exceptions/evmone_exceptions.py
+++ b/src/ethereum_test_tools/exceptions/evmone_exceptions.py
@@ -69,6 +69,7 @@ class EvmoneExceptionMapper:
         ),
         ExceptionMessage(EOFException.INVALID_MAX_STACK_HEIGHT, "err: invalid_max_stack_height"),
         ExceptionMessage(EOFException.INVALID_DATALOADN_INDEX, "err: invalid_dataloadn_index"),
+        ExceptionMessage(EOFException.TRUNCATED_INSTRUCTION, "err: truncated_instruction"),
     )
 
     def __init__(self) -> None:

--- a/src/ethereum_test_tools/exceptions/exceptions.py
+++ b/src/ethereum_test_tools/exceptions/exceptions.py
@@ -680,6 +680,10 @@ class EOFException(ExceptionBase):
     """
     A DATALOADN instruction has out-of-bounds index for the data section.
     """
+    TRUNCATED_INSTRUCTION = auto()
+    """
+    EOF container's code section has truncated instruction.
+    """
 
 
 """

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/helpers.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/helpers.py
@@ -2,6 +2,7 @@
 EOF RJump tests helpers
 """
 import itertools
+from enum import Enum
 
 """Storage addresses for common testing fields"""
 _slot = itertools.count()
@@ -14,3 +15,12 @@ slot_last_slot = next(_slot)
 value_code_worked = 0x2015
 value_calldata_true = 10
 value_calldata_false = 11
+
+
+class JumpDirection(Enum):
+    """
+    Enum for the direction of the jump
+    """
+
+    FORWARD = 1
+    BACKWARD = -1

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/spec.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/spec.py
@@ -1,5 +1,0 @@
-"""
-EOF V1 Constants used throughout all tests
-"""
-
-EOF_FORK_NAME = "Prague"

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -396,7 +396,7 @@ def test_rjump_into_push_n(
     data_portion_end: bool,
 ):
     """EOF1I4200_0011 (Invalid) EOF code containing RJUMP with target PUSH2+ immediate"""
-    data_portion_length = int.from_bytes(opcode) - 0x5F
+    data_portion_length = int.from_bytes(opcode, byteorder="big") - 0x5F
     if jump == JumpDirection.FORWARD:
         offset = data_portion_length if data_portion_end else 1
         code = Op.RJUMP[offset] + opcode[0]

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -9,7 +9,7 @@ from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
-from .helpers import slot_code_worked, value_code_worked
+from .. import EOF_FORK_NAME
 from .spec import EOF_FORK_NAME
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4200.md"

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjump.py
@@ -10,7 +10,7 @@ from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
-from .spec import EOF_FORK_NAME
+from .helpers import JumpDirection, slot_code_worked, value_code_worked
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4200.md"
 REFERENCE_SPEC_VERSION = "17d4a8d12d2b5e0f2985c866376c16c8c6df7cba"
@@ -115,7 +115,7 @@ def test_rjump_truncated_rjump(
         data=Container(
             sections=[Section.Code(code=Op.RJUMP, code_outputs=NON_RETURNING_SECTION)],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
@@ -127,7 +127,7 @@ def test_rjump_truncated_rjump_2(
         data=Container(
             sections=[Section.Code(code=Op.RJUMP + Op.STOP, code_outputs=NON_RETURNING_SECTION)],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
@@ -327,15 +327,17 @@ def test_rjump_into_rjumpi(
     )
 
 
-def test_rjump_into_push(
-    eof_test: EOFTestFiller,
-):
-    """EOF1I4200_0011 (Invalid) EOF code containing RJUMP with target PUSH immediate"""
+@pytest.mark.parametrize("jump", [JumpDirection.FORWARD, JumpDirection.BACKWARD])
+def test_rjump_into_push_1(eof_test: EOFTestFiller, jump: JumpDirection):
+    """EOF1I4200_0011 (Invalid) EOF code containing RJUMP with target PUSH1 immediate"""
+    code = (
+        Op.PUSH1[1] + Op.RJUMP[-4] if jump == JumpDirection.BACKWARD else Op.RJUMP[1] + Op.PUSH1[1]
+    )
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMP[-4],
+                    code=code,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
@@ -345,15 +347,99 @@ def test_rjump_into_push(
     )
 
 
-def test_rjump_into_rjumpv(
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.PUSH2,
+        Op.PUSH3,
+        Op.PUSH4,
+        Op.PUSH5,
+        Op.PUSH6,
+        Op.PUSH7,
+        Op.PUSH8,
+        Op.PUSH9,
+        Op.PUSH10,
+        Op.PUSH11,
+        Op.PUSH12,
+        Op.PUSH13,
+        Op.PUSH14,
+        Op.PUSH15,
+        Op.PUSH16,
+        Op.PUSH17,
+        Op.PUSH18,
+        Op.PUSH19,
+        Op.PUSH20,
+        Op.PUSH21,
+        Op.PUSH22,
+        Op.PUSH23,
+        Op.PUSH24,
+        Op.PUSH25,
+        Op.PUSH26,
+        Op.PUSH27,
+        Op.PUSH28,
+        Op.PUSH29,
+        Op.PUSH30,
+        Op.PUSH31,
+        Op.PUSH32,
+    ],
+)
+@pytest.mark.parametrize("jump", [JumpDirection.FORWARD, JumpDirection.BACKWARD])
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
+def test_rjump_into_push_n(
     eof_test: EOFTestFiller,
+    opcode: Op,
+    jump: JumpDirection,
+    data_portion_end: bool,
 ):
-    """EOF1I4200_0012 (Invalid) EOF code containing RJUMP with target RJUMPV immediate"""
+    """EOF1I4200_0011 (Invalid) EOF code containing RJUMP with target PUSH2+ immediate"""
+    data_portion_length = int.from_bytes(opcode) - 0x5F
+    if jump == JumpDirection.FORWARD:
+        offset = data_portion_length if data_portion_end else 1
+        code = Op.RJUMP[offset] + opcode[0]
+    else:
+        offset = -4 if data_portion_end else -4 - data_portion_length + 1
+        code = opcode[0] + Op.RJUMP[offset]
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.RJUMP[5] + Op.STOP + Op.PUSH1(1) + Op.RJUMPV[0] + Op.STOP,
+                    code=code,
+                    code_outputs=NON_RETURNING_SECTION,
+                    max_stack_height=1,
+                ),
+            ],
+        ),
+        expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
+    )
+
+
+@pytest.mark.parametrize("target_rjumpv_table_size", [1, 256])
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
+def test_rjump_into_rjumpv(
+    eof_test: EOFTestFiller,
+    target_rjumpv_table_size: int,
+    data_portion_end: bool,
+):
+    """EOF1I4200_0012 (Invalid) EOF code containing RJUMP with target RJUMPV immediate"""
+    invalid_destination = 4 + (2 * target_rjumpv_table_size) if data_portion_end else 4
+    target_jump_table = [0 for _ in range(target_rjumpv_table_size)]
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.RJUMP[invalid_destination]
+                    + Op.STOP
+                    + Op.PUSH1(1)
+                    + Op.RJUMPV[target_jump_table]
+                    + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -363,15 +449,22 @@ def test_rjump_into_rjumpv(
     )
 
 
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjump_into_callf(
     eof_test: EOFTestFiller,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0013 (Invalid) EOF code containing RJUMP with target CALLF immediate"""
+    invalid_destination = 2 if data_portion_end else 1
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.RJUMP[2] + Op.CALLF(1) + Op.STOP,
+                    code=Op.RJUMP[invalid_destination] + Op.CALLF[1] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                 ),
                 Section.Code(

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -18,6 +18,7 @@ from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
+from .. import EOF_FORK_NAME
 from .helpers import (
     slot_code_worked,
     slot_conditional_result,

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -561,7 +561,7 @@ def test_rjumpi_into_push_n(
     data_portion_end: bool,
 ):
     """EOF1I4200_0024 (Invalid) EOF code containing RJUMPI with target PUSH2+ immediate"""
-    data_portion_length = int.from_bytes(opcode) - 0x5F
+    data_portion_length = int.from_bytes(opcode, byteorder="big") - 0x5F
     if jump == JumpDirection.FORWARD:
         offset = data_portion_length if data_portion_end else 1
         code = Op.PUSH1(1) + Op.RJUMPI[offset] + opcode[0]

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -777,7 +777,7 @@ def test_rjumpv_into_push_n(
     data_portion_end: bool,
 ):
     """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSH1 immediate"""
-    data_portion_length = int.from_bytes(opcode) - 0x5F
+    data_portion_length = int.from_bytes(opcode, byteorder="big") - 0x5F
     if jump == JumpDirection.FORWARD:
         invalid_destination = data_portion_length + 1 if data_portion_end else 2
         jump_table = [0 for _ in range(table_size)]

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -18,7 +18,7 @@ from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
-from .helpers import slot_code_worked, slot_conditional_result, value_code_worked
+from .. import EOF_FORK_NAME
 from .spec import EOF_FORK_NAME
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4200.md"

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -4,22 +4,13 @@ EOF JUMPF tests covering stack and code validation rules.
 
 import pytest
 
-from ethereum_test_tools import (
-    Account,
-    Environment,
-    EOFException,
-    EOFStateTestFiller,
-    EOFTestFiller,
-    StateTestFiller,
-    TestAddress,
-    Transaction,
-)
+from ethereum_test_tools import Account, EOFException, EOFStateTestFiller, EOFTestFiller
 from ethereum_test_tools.eof.v1 import Container, Section
 from ethereum_test_tools.eof.v1.constants import NON_RETURNING_SECTION
 from ethereum_test_tools.vm.opcode import Opcodes as Op
 
 from .. import EOF_FORK_NAME
-from .spec import EOF_FORK_NAME
+from .helpers import JumpDirection, slot_code_worked, slot_conditional_result, value_code_worked
 
 REFERENCE_SPEC_GIT_PATH = "EIPS/eip-4200.md"
 REFERENCE_SPEC_VERSION = "17d4a8d12d2b5e0f2985c866376c16c8c6df7cba"
@@ -30,11 +21,12 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
 @pytest.mark.parametrize(
     "calldata",
     [
-        pytest.param(b"\0" * 32, id="c0"),
-        pytest.param(b"\0" * 31 + b"\x01", id="c1"),
-        pytest.param(b"\0" * 31 + b"\x03", id="c3"),
-        pytest.param(b"\0" * 30 + b"\x10\x00", id="c256"),
-        pytest.param(b"\xff" * 32, id="cmax"),
+        pytest.param(0, id="c0"),
+        pytest.param(1, id="c1"),
+        pytest.param(3, id="c3"),
+        pytest.param(255, id="c255"),
+        pytest.param(256, id="c256"),
+        pytest.param(2**256 - 1, id="c2^256-1"),
     ],
 )
 @pytest.mark.parametrize(
@@ -46,65 +38,44 @@ pytestmark = pytest.mark.valid_from(EOF_FORK_NAME)
     ],
 )
 def test_rjumpv_condition(
-    state_test: StateTestFiller,
-    calldata: bytes,
+    eof_state_test: EOFStateTestFiller,
+    calldata: int,
     table_size: int,
 ):
     """Test RJUMPV contract switching based on external input"""
     value_fall_through = 0xFFFF
-    value_base = 0x1000
-
-    jump_table = b""
-    for i in range(table_size):
-        jump_table += int.to_bytes((i + 1) * 7, 2, "big")
+    value_base = 0x1000  # Force a `PUSH2` instruction to be used on all targets
+    target_length = 7
+    jump_table = [(i + 1) * target_length for i in range(table_size)]
 
     jump_targets = b""
     for i in range(table_size):
         jump_targets += Op.SSTORE(slot_conditional_result, i + value_base) + Op.STOP
 
-    env = Environment()
-    tx = Transaction(
-        nonce=1,
-        gas_limit=10_000_000,
-        data=calldata,
-    )
-    pre = {
-        TestAddress: Account(balance=10**18, nonce=tx.nonce),
-        tx.to: Account(
-            code=Container(
-                sections=[
-                    Section.Code(
-                        code=Op.PUSH0
-                        + Op.CALLDATALOAD
-                        + Op.RJUMPV
-                        + int.to_bytes(table_size - 1, 1, "big")
-                        + jump_table
-                        + Op.SSTORE(slot_conditional_result, value_fall_through)
-                        + Op.STOP
-                        + jump_targets,
-                        code_outputs=NON_RETURNING_SECTION,
-                        max_stack_height=2,
-                    )
-                ]
-            ),
-            nonce=1,
+    fall_through_case = Op.SSTORE(slot_conditional_result, value_fall_through) + Op.STOP
+
+    eof_state_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=Op.PUSH0
+                    + Op.CALLDATALOAD
+                    + Op.RJUMPV[jump_table]
+                    + fall_through_case
+                    + jump_targets,
+                    code_outputs=NON_RETURNING_SECTION,
+                    max_stack_height=2,
+                )
+            ]
         ),
-    }
-    calldata_int = int.from_bytes(calldata, "big")
-    post = {
-        tx.to: Account(
+        tx_data=calldata.to_bytes(32, "big"),
+        container_post=Account(
             storage={
-                slot_conditional_result: calldata_int + 0x1000
-                if calldata_int < table_size
+                slot_conditional_result: calldata + value_base
+                if calldata < table_size
                 else value_fall_through,
             }
-        )
-    }
-    state_test(
-        env=env,
-        tx=tx,
-        pre=pre,
-        post=post,
+        ),
     )
 
 
@@ -325,7 +296,7 @@ def test_rjumpv_truncated(
                 )
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
@@ -343,7 +314,7 @@ def test_rjumpv_truncated_1(
                 )
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
     #     - data: |
 
@@ -362,7 +333,7 @@ def test_rjumpv_truncated_2(
                 )
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
@@ -380,7 +351,7 @@ def test_rjumpv_truncated_3(
                 )
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
@@ -398,22 +369,35 @@ def test_rjumpv_truncated_4(
                 )
             ],
         ),
-        expect_exception=EOFException.UNDEFINED_EXCEPTION,
+        expect_exception=EOFException.TRUNCATED_INSTRUCTION,
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_header(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """
     EOF1I4200_0031 (Invalid) EOF code containing RJUMPV with target outside code bounds
     (Jumping into header)
     """
+    invalid_destination = -5 - (2 * table_size)
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[-7] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -423,18 +407,31 @@ def test_rjumpv_into_header(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_before_container(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """
     EOF1I4200_0032 (Invalid) EOF code containing RJUMPV with target outside code bounds
     (Jumping to before code begin)
     """
+    invalid_destination = -13 - (2 * table_size)
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[-15] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -444,39 +441,66 @@ def test_rjumpv_before_container(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_data(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """
     EOF1I4200_0033 (Invalid) EOF code containing RJUMPV with target outside code bounds
     (Jumping into data section)
     """
+    invalid_destination = 2
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[2] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
-                )
+                ),
+                Section.Data(data=b"\xaa\xbb\xcc"),
             ],
         ),
         expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_after_container(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """
     EOF1I4200_0034 (Invalid) EOF code containing RJUMPV with target outside code bounds
     (Jumping to after code end)
     """
+    invalid_destination = 2
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[2] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -486,18 +510,31 @@ def test_rjumpv_after_container(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_at_end(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """
     EOF1I4200_0035 (Invalid) EOF code containing RJUMPV with target outside code bounds
     (Jumping to code end)
     """
+    invalid_destination = 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[1] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -507,15 +544,34 @@ def test_rjumpv_at_end(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjumpv_into_self(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0036 (Invalid) EOF code containing RJUMPV with target same RJUMPV immediate"""
+    invalid_destination = -1 if data_portion_end else -(2 * table_size) - 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1) + Op.RJUMPV[-1] + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -525,20 +581,39 @@ def test_rjumpv_into_self(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjumpv_into_rjump(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0037 (Invalid) EOF code containing RJUMPV with target RJUMP immediate"""
+    invalid_destination = 3 if data_portion_end else 2
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
+    if table_size > 1:
+        valid_index = 0
+        if valid_index == invalid_index:
+            valid_index += 1
+        jump_table[valid_index] = 1
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1)
-                    + Op.RJUMPV[5]
-                    + Op.STOP
-                    + Op.PUSH1(1)
-                    + Op.RJUMP[-9]
-                    + Op.STOP,
+                    code=Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP + Op.RJUMP[0] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -548,19 +623,43 @@ def test_rjumpv_into_rjump(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjumpv_into_rjumpi(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0038 (Invalid) EOF code containing RJUMPV with target RJUMPI immediate"""
+    invalid_destination = 5 if data_portion_end else 4
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
+    if table_size > 1:
+        valid_index = 0
+        if valid_index == invalid_index:
+            valid_index += 1
+        jump_table[valid_index] = 1
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
-                    + Op.RJUMPV[5]
+                    + Op.RJUMPV[jump_table]
                     + Op.STOP
                     + Op.PUSH1(1)
-                    + Op.RJUMPI[-9]
+                    + Op.RJUMPI[0]
                     + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
@@ -571,21 +670,45 @@ def test_rjumpv_into_rjumpi(
     )
 
 
-def test_rjumpv_into_push(
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize("jump", [JumpDirection.FORWARD, JumpDirection.BACKWARD])
+def test_rjumpv_into_push_1(
     eof_test: EOFTestFiller,
+    jump: JumpDirection,
+    table_size: int,
+    invalid_index: int,
 ):
-    """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSH immediate"""
+    """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSH1 immediate"""
+    if jump == JumpDirection.FORWARD:
+        invalid_destination = 2
+        jump_table = [0 for _ in range(table_size)]
+        jump_table[invalid_index] = invalid_destination
+        code = (
+            Op.PUSH1(1)
+            + Op.RJUMPV[jump_table]
+            + Op.STOP
+            + Op.PUSH1(1)
+            + Op.PUSH1(1)
+            + Op.SSTORE
+            + Op.STOP
+        )
+    else:
+        invalid_destination = -(2 * table_size) - 3
+        jump_table = [0 for _ in range(table_size)]
+        jump_table[invalid_index] = invalid_destination
+        code = Op.PUSH1(1) + Op.RJUMPV[jump_table] + Op.STOP
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(1)
-                    + Op.RJUMPV[2]
-                    + Op.STOP
-                    + Op.PUSH1(1)
-                    + Op.PUSH1(1)
-                    + Op.SSTORE
-                    + Op.STOP,
+                    code=code,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 )
@@ -595,19 +718,137 @@ def test_rjumpv_into_push(
     )
 
 
+@pytest.mark.parametrize(
+    "opcode",
+    [
+        Op.PUSH2,
+        Op.PUSH3,
+        Op.PUSH4,
+        Op.PUSH5,
+        Op.PUSH6,
+        Op.PUSH7,
+        Op.PUSH8,
+        Op.PUSH9,
+        Op.PUSH10,
+        Op.PUSH11,
+        Op.PUSH12,
+        Op.PUSH13,
+        Op.PUSH14,
+        Op.PUSH15,
+        Op.PUSH16,
+        Op.PUSH17,
+        Op.PUSH18,
+        Op.PUSH19,
+        Op.PUSH20,
+        Op.PUSH21,
+        Op.PUSH22,
+        Op.PUSH23,
+        Op.PUSH24,
+        Op.PUSH25,
+        Op.PUSH26,
+        Op.PUSH27,
+        Op.PUSH28,
+        Op.PUSH29,
+        Op.PUSH30,
+        Op.PUSH31,
+        Op.PUSH32,
+    ],
+)
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
+@pytest.mark.parametrize("jump", [JumpDirection.FORWARD, JumpDirection.BACKWARD])
+def test_rjumpv_into_push_n(
+    eof_test: EOFTestFiller,
+    opcode: Op,
+    jump: JumpDirection,
+    table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
+):
+    """EOF1I4200_0039 (Invalid) EOF code containing RJUMPV with target PUSH1 immediate"""
+    data_portion_length = int.from_bytes(opcode) - 0x5F
+    if jump == JumpDirection.FORWARD:
+        invalid_destination = data_portion_length + 1 if data_portion_end else 2
+        jump_table = [0 for _ in range(table_size)]
+        jump_table[invalid_index] = invalid_destination
+        code = (
+            Op.PUSH1(1)
+            + Op.RJUMPV[jump_table]
+            + Op.STOP
+            + opcode[1]
+            + Op.PUSH1(1)
+            + Op.SSTORE
+            + Op.STOP
+        )
+    else:
+        invalid_destination = (
+            -(2 * table_size) - 3
+            if data_portion_end
+            else -(2 * table_size) - 2 - data_portion_length
+        )
+        jump_table = [0 for _ in range(table_size)]
+        jump_table[invalid_index] = invalid_destination
+        code = opcode[1] + Op.RJUMPV[jump_table] + Op.STOP
+    eof_test(
+        data=Container(
+            sections=[
+                Section.Code(
+                    code=code,
+                    code_outputs=NON_RETURNING_SECTION,
+                    max_stack_height=1,
+                )
+            ],
+        ),
+        expect_exception=EOFException.INVALID_RJUMP_DESTINATION,
+    )
+
+
+@pytest.mark.parametrize(
+    "source_table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="s1i0"),
+        pytest.param(256, 0, id="s256i0"),
+        pytest.param(256, 255, id="s256i255"),
+    ],
+)
+@pytest.mark.parametrize("target_table_size", [1, 256], ids=["t1", "t256"])
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjumpv_into_rjumpv(
     eof_test: EOFTestFiller,
+    source_table_size: int,
+    target_table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0040 (Invalid) EOF code containing RJUMPV with target other RJUMPV immediate"""
+    invalid_destination = 4 + (2 * target_table_size) if data_portion_end else 4
+    source_jump_table = [0 for _ in range(source_table_size)]
+    source_jump_table[invalid_index] = invalid_destination
+    target_jump_table = [0 for _ in range(target_table_size)]
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
                     code=Op.PUSH1(1)
-                    + Op.RJUMPV[5]
+                    + Op.RJUMPV[source_jump_table]
                     + Op.STOP
                     + Op.PUSH1(1)
-                    + Op.RJUMPV[0]
+                    + Op.RJUMPV[target_jump_table]
                     + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
@@ -618,15 +859,34 @@ def test_rjumpv_into_rjumpv(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
+@pytest.mark.parametrize(
+    "data_portion_end",
+    [True, False],
+    ids=["data_portion_end", "data_portion_start"],
+)
 def test_rjumpv_into_callf(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
+    data_portion_end: bool,
 ):
     """EOF1I4200_0041 (Invalid) EOF code containing RJUMPV with target CALLF immediate"""
+    invalid_destination = 2 if data_portion_end else 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(0) + Op.RJUMPV[2] + Op.CALLF[1] + Op.STOP,
+                    code=Op.PUSH1(0) + Op.RJUMPV[jump_table] + Op.CALLF[1] + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=1,
                 ),
@@ -641,10 +901,23 @@ def test_rjumpv_into_callf(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_dupn(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """EOF code containing RJUMP with target DUPN immediate"""
+    invalid_destination = 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
@@ -652,7 +925,7 @@ def test_rjumpv_into_dupn(
                     code=Op.PUSH1(1)
                     + Op.PUSH1(1)
                     + Op.PUSH1(0)
-                    + Op.RJUMPV[1]
+                    + Op.RJUMPV[jump_table]
                     + Op.DUPN[1]
                     + Op.SSTORE
                     + Op.STOP,
@@ -665,10 +938,23 @@ def test_rjumpv_into_dupn(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_swapn(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """EOF code containing RJUMP with target SWAPN immediate"""
+    invalid_destination = 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
@@ -676,7 +962,7 @@ def test_rjumpv_into_swapn(
                     code=Op.PUSH1(1)
                     + Op.PUSH1(1)
                     + Op.PUSH1(0)
-                    + Op.RJUMPV[1]
+                    + Op.RJUMPV[jump_table]
                     + Op.SWAPN[1]
                     + Op.SSTORE
                     + Op.STOP,
@@ -689,10 +975,23 @@ def test_rjumpv_into_swapn(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjump_into_exchange(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """EOF code containing RJUMP with target EXCHANGE immediate"""
+    invalid_destination = 1
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
@@ -714,15 +1013,31 @@ def test_rjump_into_exchange(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_eofcreate(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """EOF code containing RJUMP with target EOFCREATE immediate"""
+    invalid_destination = 9
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
                 Section.Code(
-                    code=Op.PUSH1(0) + Op.RJUMPV[9] + Op.EOFCREATE[0](0, 0, 0, 0) + Op.STOP,
+                    code=Op.PUSH1(0)
+                    + Op.RJUMPV[jump_table]
+                    + Op.EOFCREATE[0](0, 0, 0, 0)
+                    + Op.STOP,
                     code_outputs=NON_RETURNING_SECTION,
                     max_stack_height=4,
                 ),
@@ -753,10 +1068,23 @@ def test_rjumpv_into_eofcreate(
     )
 
 
+@pytest.mark.parametrize(
+    "table_size,invalid_index",
+    [
+        pytest.param(1, 0, id="t1i0"),
+        pytest.param(256, 0, id="t256i0"),
+        pytest.param(256, 255, id="t256i255"),
+    ],
+)
 def test_rjumpv_into_returncontract(
     eof_test: EOFTestFiller,
+    table_size: int,
+    invalid_index: int,
 ):
     """EOF code containing RJUMP with target RETURNCONTRACT immediate"""
+    invalid_destination = 5
+    jump_table = [0 for _ in range(table_size)]
+    jump_table[invalid_index] = invalid_destination
     eof_test(
         data=Container(
             sections=[
@@ -769,7 +1097,9 @@ def test_rjumpv_into_returncontract(
                     container=Container(
                         sections=[
                             Section.Code(
-                                code=Op.PUSH1(0) + Op.RJUMPV[5] + Op.RETURNCONTRACT[0](0, 0),
+                                code=Op.PUSH1(0)
+                                + Op.RJUMPV[jump_table]
+                                + Op.RETURNCONTRACT[0](0, 0),
                                 code_outputs=NON_RETURNING_SECTION,
                                 max_stack_height=2,
                             ),


### PR DESCRIPTION
## 🗒️ Description
Contains the following changes:
- Add `TRUNCATED_INSTRUCTION` EOF exception.
- Add RJUMP* into data portion of PUSH2-PUSH32.
- Parameterize RJUMP* functions that jump into a data portion of 2+ bytes  (PUSH*, RJUMP*, CALLF) in order to test jumping into the beginning and end of the data.
- Refactor `test_rjumpv_condition`
- Add parameterization to RJUMPV tests that jump to invalid destinations to make the invalid destination appear on different indexes of the jump table, and multiple jump table sizes too.

I also force-rebased [shemnon:eof/rjump](https://github.com/shemnon/execution-spec-tests/tree/eof/rjump) to main in order to make first commit possible.

@shemnon 