### PR TITLE
feat(fw): Implement `deploy_tx` option for `eof_state_test`

### DIFF
--- a/src/ethereum_test_tools/spec/eof/eof_test.py
+++ b/src/ethereum_test_tools/spec/eof/eof_test.py
@@ -264,6 +264,7 @@ class EOFStateTest(EOFTest):
     Filler type that tests EOF containers and also generates a state/blockchain test.
     """
 
+    deploy_tx: bool = False
     tx_gas_limit: int = 10_000_000
     tx_data: Bytes = Bytes(b"")
     tx_sender_funding_amount: int = 1_000_000_000_000_000_000_000
@@ -290,16 +291,23 @@ class EOFStateTest(EOFTest):
         Generate the StateTest filler.
         """
         assert self.pre is not None, "pre must be set to generate a StateTest."
-        container_address = self.pre.deploy_contract(code=self.data)
         sender = self.pre.fund_eoa(amount=self.tx_sender_funding_amount)
-        tx = Transaction(
-            to=container_address,
-            gas_limit=self.tx_gas_limit,
-            gas_price=10,
-            protected=False,
-            data=self.tx_data,
-            sender=sender,
-        )
+        if self.deploy_tx:
+            tx = Transaction(
+                to=None,
+                gas_limit=self.tx_gas_limit,
+                data=self.data + self.tx_data,
+                sender=sender,
+            )
+            container_address = tx.created_contract
+        else:
+            container_address = self.pre.deploy_contract(code=self.data)
+            tx = Transaction(
+                to=container_address,
+                gas_limit=self.tx_gas_limit,
+                data=self.tx_data,
+                sender=sender,
+            )
         post = Alloc()
         post[container_address] = self.container_post
         return StateTest(


### PR DESCRIPTION
## 🗒️ Description
Implements a field for `eof_state_test` that allows an eof state test to send a contract-creating tx instead of placing the container in the `pre`.