### PR TITLE
Add test variants

### DIFF
--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpi.py
@@ -912,13 +912,37 @@ def test_rjumpi_backwards_min_stack_wrong(
     """
     container = Container.Code(
         code=(
-            Op.PUSH0
-            + Op.PUSH1(0)
-            + Op.RJUMPI[1]
-            + Op.PUSH0
-            + Op.PUSH1(4)
-            + Op.RJUMPI[-9]
-            + Op.STOP
+            Op.PUSH0  # (0, 0)
+            + Op.PUSH1(0)  # (1, 1)
+            + Op.RJUMPI[1]  # (2, 2) To PUSH1
+            + Op.PUSH0  # (1, 1)
+            + Op.PUSH1(4)  # (1, 2)
+            + Op.RJUMPI[-9]  # (2, 3) To first RJUMPI with (1, 2)
+            + Op.STOP  # (1, 2)
+        ),
+        max_stack_height=3,
+    )
+    eof_test(
+        data=container,
+        expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
+    )
+
+
+def test_rjumpi_rjumpv_backwards_min_stack_wrong(
+    eof_test: EOFTestFiller,
+):
+    """
+    Backwards rjumpv where min_stack does not match
+    """
+    container = Container.Code(
+        code=(
+            Op.PUSH0  # (0, 0)
+            + Op.PUSH1(0)  # (1, 1)
+            + Op.RJUMPI[1]  # (2, 2) To PUSH1
+            + Op.PUSH0  # (1, 1)
+            + Op.PUSH1(4)  # (1, 2)
+            + Op.RJUMPV[-10]  # (2, 3) To first RJUMPI with (1, 2)
+            + Op.STOP  # (1, 2)
         ),
         max_stack_height=3,
     )
@@ -935,7 +959,15 @@ def test_double_rjumpi(
     Two RJUNMPIs, causing the min stack to underflow
     """
     container = Container.Code(
-        code=(Op.PUSH0 + Op.PUSH0 + Op.RJUMPI[5] + Op.PUSH0 + Op.PUSH0 + Op.RJUMPI[0] + Op.RETURN),
+        code=(
+            Op.PUSH0  # (0, 0)
+            + Op.PUSH0  # (1, 1)
+            + Op.RJUMPI[5]  # (2, 2) To RETURN
+            + Op.PUSH0  # (1, 1)
+            + Op.PUSH0  # (2, 2)
+            + Op.RJUMPI[0]  # (3, 3)
+            + Op.RETURN  # (1, 2) Underflow
+        ),
         max_stack_height=3,
     )
     eof_test(

--- a/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
+++ b/tests/prague/eip7692_eof_v1/eip4200_relative_jumps/test_rjumpv.py
@@ -1188,13 +1188,37 @@ def test_rjumpv_backwards_min_stack_wrong(
     """
     container = Container.Code(
         code=(
-            Op.PUSH0
-            + Op.PUSH1(0)
-            + Op.RJUMPV[1]
-            + Op.PUSH0
-            + Op.PUSH1(4)
-            + Op.RJUMPV[-11]
-            + Op.STOP
+            Op.PUSH0  # (0, 0)
+            + Op.PUSH1(0)  # (1, 1)
+            + Op.RJUMPV[1]  # (2, 2) To PUSH1
+            + Op.PUSH0  # (1, 1)
+            + Op.PUSH1(4)  # (1, 2)
+            + Op.RJUMPV[-11]  # (2, 3) To first RJUMPV with (1, 2)
+            + Op.STOP  # (1, 2)
+        ),
+        max_stack_height=3,
+    )
+    eof_test(
+        data=container,
+        expect_exception=EOFException.STACK_HEIGHT_MISMATCH,
+    )
+
+
+def test_rjumpv_rjumpi_backwards_min_stack_wrong(
+    eof_test: EOFTestFiller,
+):
+    """
+    Backwards rjumpv where min_stack does not match
+    """
+    container = Container.Code(
+        code=(
+            Op.PUSH0  # (0, 0)
+            + Op.PUSH1(0)  # (1, 1)
+            + Op.RJUMPV[1]  # (2, 2) To PUSH1
+            + Op.PUSH0  # (1, 1)
+            + Op.PUSH1(4)  # (1, 2)
+            + Op.RJUMPI[-10]  # (2, 3) To first RJUMPV with (1, 2)
+            + Op.STOP  # (1, 2)
         ),
         max_stack_height=3,
     )


### PR DESCRIPTION
Added some comments and test variants to the tests you added.

I might be missing something but I feel like `test_jumpf_diff_max_stack_height` should have the same failure across all parametrized test vectors, because the spec states that the min and max stack heights should be the same, but shouldn't this check come first?

Let me know what you think.